### PR TITLE
Begin review

### DIFF
--- a/content/en/docs/02.0/build-container-image.md
+++ b/content/en/docs/02.0/build-container-image.md
@@ -132,11 +132,9 @@ curl localhost:8088/world
 ### Publish image to Docker Hub
 
 To make the image accessible to OpenShift, it must be pushed to an image registry. We use Docker Hub as the registry.
-
+<!-- sgl: split the two commands in two fields so it can be cop easier -->
 ```bash
 podman login
-```
-<!-- sgl: The resulting Image couldn't be used with oc new-app -->
-```bash
+# sgl: The resulting Image couldn't be used with oc new-app
 podman push localhost/go-hello-world:latest docker://docker.io/appuio/go-hello-world:latest
 ```

--- a/content/en/docs/02.0/build-container-image.md
+++ b/content/en/docs/02.0/build-container-image.md
@@ -15,6 +15,7 @@ The sample application is an HTTP server written in the [Go programming language
 
 The following files are needed inside your application repository:
 
+<!-- sgl: Dockerfilepath doesn't work -->
 * [Dockerfile](#application-build-instruction)
 * [main.go](#sample-go-application)
 
@@ -135,7 +136,7 @@ To make the image accessible to OpenShift, it must be pushed to an image registr
 ```bash
 podman login
 ```
-
+<!-- sgl: The resulting Image couldn't be used with oc new-app -->
 ```bash
 podman push localhost/go-hello-world:latest docker://docker.io/appuio/go-hello-world:latest
 ```

--- a/content/en/docs/02.0/build-container-image.md
+++ b/content/en/docs/02.0/build-container-image.md
@@ -132,9 +132,11 @@ curl localhost:8088/world
 ### Publish image to Docker Hub
 
 To make the image accessible to OpenShift, it must be pushed to an image registry. We use Docker Hub as the registry.
-<!-- sgl: split the two commands in two fields so it can be cop easier -->
 ```bash
 podman login
+```
+
+```bash
 # sgl: The resulting Image couldn't be used with oc new-app
 podman push localhost/go-hello-world:latest docker://docker.io/appuio/go-hello-world:latest
 ```

--- a/content/en/docs/02.0/odo.md
+++ b/content/en/docs/02.0/odo.md
@@ -86,6 +86,7 @@ MaxCPU
 Create the file `main.go` with the content of the go-hello-world application ([source](https://raw.githubusercontent.com/puzzle/amm-techlab/master/content/en/docs/02.0/main.go)).
 
 ```bash
+# sgl: This path doesn't include the odo-application path. Plus it assumes that the amm-techlab git-repo is checked out
 cp content/en/docs/02.0/main.go main.go
 ```
 

--- a/content/en/docs/03.0/3.1/containerize.md
+++ b/content/en/docs/03.0/3.1/containerize.md
@@ -88,6 +88,7 @@ spec:
   runPolicy: Serial
   source:
     git:
+      # sgl: There is no description to fork the repo. So either use the appuio repo or add description to clone the repo
       uri: https://github.com/userXY/example-spring-boot-helloworld
     type: Git
   strategy:
@@ -179,7 +180,7 @@ imagestream.image.openshift.io/openjdk-11 created
 
 
 ### Deployment
-
+<!-- sgl: create deployment.yaml -->
 After the ImageStream definition we can setup our Deployment. Please note the Deployment annotation `image.openshift.io/triggers`, this annotation connects the Deployment with the ImageStreamTag (which is automatically created by the ImageSource object)
 
 ```YAML
@@ -279,6 +280,7 @@ metadata:
     app: appuio-spring-boot-ex
   name: appuio-spring-boot-ex
 spec:
+  # sgl: Wrong route. This is the Puzzle and not Techlab specific route
   host: appuio-spring-boot-ex-spring-boot-userXY.ocp.aws.puzzle.ch
   port:
     targetPort: 8080-tcp

--- a/content/en/docs/03.0/3.3/openshift-images.md
+++ b/content/en/docs/03.0/3.3/openshift-images.md
@@ -6,7 +6,7 @@ sectionnumber: 3.3
 description: >
   This section is covering how to build a runnable image for OpenShift clusters.
 ---
-
+<!-- sgl: A bit weird to have a Go Application in the Java section ;)  -->
 ## Application
 
 We use the same Go application from Lab 2 and extend it with a log file. Every request is logged with the actual time and the client IP address. The log file is placed under `/home/golang/hello-go.log`
@@ -71,6 +71,7 @@ func appendToFile(remoteAddr string) {
 
 The dockerfile is the same as in chapter 2.
 
+<!-- sgl: This code didn't work for me but the included Dockerfile from this repo worked. -->
 ``` dockerfile
 FROM golang:1.14-alpine as builder
 COPY main.go /opt/app-root/src
@@ -214,7 +215,7 @@ buildah bud -f Dockerfile -t go-hello-world-os .
 ```BASH
 podman push localhost/go-hello-world-os docker://docker.io/appuio/go-hello-world.os:latest
 ```
-
+<!-- sgl: The Image doesn't automatically update -->
 
 ```BASH
 oc logs go-hello-world-os-576dcb6994-xwn6b
@@ -274,6 +275,7 @@ oc get pods
 
 ## Create route
 
+<!-- sgl: error: you need to provide a route port via --port when exposing a non-existent service -->
 ```BASH
 oc create route edge --service=go-hello
 ```


### PR DESCRIPTION
Specific improvments are in the Code.

General improvments:
* The tooling isn't quiet refined. The online IDE has only oc and odo. So everything else has to be done locally. The labs sometimes use docker and sometimes podman. In my playthrough only docker worked properly. Most developers have docker installed but don't have buildah and podman. So I would unify all the labs with docker. Ans maybe drop the online IDE
* Some labs assume that this repo is locally available some say you have to create the code locally. Unify it so all the code needed for the Techlabs is in this repo and the user has checked it out at the beginning.
* The docker-instrucions lab is the same as the end of the build-container-image. The only difference is the Tool used.