### PR TITLE
Add source to svc.yaml in kafka chapter

### DIFF
--- a/content/en/docs/03.0/kafka/kafka.md
+++ b/content/en/docs/03.0/kafka/kafka.md
@@ -346,6 +346,8 @@ spec:
 {{< / highlight >}}
 ```
 
+[source](https://raw.githubusercontent.com/puzzle/amm-techlab/master/manifests/03.0/3.2/svc.yaml)
+
 Apply the updated Service manifest.
 
 <details><summary>command hint</summary>


### PR DESCRIPTION
Source link war nicht angegeben. Mit Link deutlich angenehmer.