### PR TITLE
pipelinerun can be created multiple times

### DIFF
--- a/content/en/docs/04.0/pipeline.md
+++ b/content/en/docs/04.0/pipeline.md
@@ -248,12 +248,12 @@ Create the PipelineRun by processing the template and creating the generated res
 ```bash
 oc process -f pipeline-run-template.yaml \
   --param=PROJECT_NAME=$(oc project -q) \
-| oc apply -f-
+| oc create -f-
 ```
 
-which will result in: `pipelinerun.tekton.dev/build-and-deploy-run-1 created`
+which will result in: `pipelinerun.tekton.dev/build-and-deploy-run-5wxbf created`
 
-This will create and execute a PipelineRun. Use the command `tkn pipelinerun logs build-and-deploy-run-1 -f -n $LAB_USER` to display the logs.
+This will create and execute a PipelineRun. Use the command `tkn pipelinerun logs build-and-deploy-run-5wxbf -f -n $LAB_USER` to display the logs.
 
 The PipelineRuns can be listed with:
 
@@ -262,8 +262,8 @@ tkn pipelinerun ls
 ```
 
 ```
-NAME                     STARTED          DURATION    STATUS
-build-and-deploy-run-1   3 minutes ago    1 minute    Succeeded
+NAME                         STARTED         DURATION   STATUS
+build-and-deploy-run-5wxbf   9 seconds ago   ---        Running
 ```
 
 Moreover, the logs can be viewed with the following command and selecting the appropriate Pipeline and PipelineRun:

--- a/manifests/04.0/4.1/pipeline-run-template.yaml
+++ b/manifests/04.0/4.1/pipeline-run-template.yaml
@@ -11,7 +11,6 @@ objects:
     generateName: build-and-deploy-run-
     labels:
       tekton.dev/pipeline: build-and-deploy
-    name: build-and-deploy-run-1
   spec:
     params:
     - name: deployment-name


### PR DESCRIPTION
oc create instead of oc apply and removed resource name.

This should let the pipelinerun be created multiple times, not only one instance.

* [ ] Lab must be tested till the end